### PR TITLE
Fix token input variable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'PR collection labeler'
 description: 'Add collection labels to pull requests according to the base branch'
 author: "Louise Poubel"
 inputs:
-  github_token:
+  github-token:
     description: "Token for the repo. Can be passed in using {{ secrets.GITHUB_TOKEN }}"
     required: true
 runs:


### PR DESCRIPTION
For some reson this used to work but it doesn't any more.

The correct variable should be `github-token`, see:

```
$ grep -r "github.*token" *.*
action.yml:  github_token:
index.js:    const token = core.getInput('github-token', { required: true });
index.js:    const gh = new github.GitHub(token);
README.md:        github-token: ${{ secrets.GITHUB_TOKEN }}
```

I tested this with https://github.com/ignitionrobotics/ign-gazebo/pull/167 and it worked.